### PR TITLE
Update ember-cli-sass to allow node 5.

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "ember-cli-jquery-ui": "0.0.20",
     "ember-cli-qunit": "^1.0.1",
     "ember-cli-release": "0.2.3",
-    "ember-cli-sass": "3.3.1",
+    "ember-cli-sass": "^5.2.0",
     "ember-cli-sri": "^1.0.3",
     "ember-cli-uglify": "^1.2.0",
     "ember-data": "2.0.0",


### PR DESCRIPTION
A more recent node-sass is required for usage under Node 5.